### PR TITLE
config_to_json filters out stanzas with -hide flag

### DIFF
--- a/tests/fixtures/fake_config_file.txt
+++ b/tests/fixtures/fake_config_file.txt
@@ -33,3 +33,5 @@ U http://fake.url-number.three/login?password=my_secret
 HosT https://fake.url-number.three
 DJ url-number.three
 
+T -HIDE hidden title
+U http://hiddentitle.com

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,5 +1,5 @@
 from utilities.config_to_json import (get_included_files, get_config_contents,
-                                      get_stanzas)
+                                      get_stanzas, filter_stanzas)
 import pytest
 import os
 
@@ -44,7 +44,15 @@ def test_get_stanzas(config_results):
     assert any(['http://fake.url-number.three' in s for s in url_list])
 
 
-def test_parse_config_keys(config_results):
-    """parse_config list contains only title, urls, and config_file keys """
+def test_get_stanzas_keys(config_results):
+    """get_stanzas list contains only title, urls, and config_file keys """
     keys = set().union(*(d.keys()for d in config_results))
     assert {'urls', 'title', 'config_file'} == keys
+
+
+def test_filter_stanzas(config_results):
+    """filter_stanazas removes stanzas with a -hide flag in the
+    title directive"""
+    x = filter_stanzas(config_results)
+    assert len(config_results) == 4
+    assert len(x) == 3

--- a/utilities/config_to_json.py
+++ b/utilities/config_to_json.py
@@ -50,6 +50,7 @@ def main():
         for data in config_file_data:
             if get_stanzas(data):
                 results.extend(get_stanzas(data))
+        results = filter_stanzas(results)
         print(json.dumps(results))
     except IndexError:
         print(
@@ -154,6 +155,15 @@ def get_stanzas(config_data: str):
     if currentstanza:
         stanzas.append(currentstanza)
         return stanzas
+
+
+def filter_stanzas(stanzas):
+    """filters things out of stanazs"""
+    filtered_stanzas = []
+    for stanza in stanzas:
+        if '-hide' not in stanza['title'].lower():
+            filtered_stanzas.append(stanza)
+    return filtered_stanzas
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
ezproxy supports a -hide flag in the title directive which will prevent that stanza from being displayed in the ezproxy database menu. ezproxy-lookup should honor the hide flag when parsing config files.